### PR TITLE
views: addition of links in response headers

### DIFF
--- a/invenio_records_rest/serializers/response.py
+++ b/invenio_records_rest/serializers/response.py
@@ -47,7 +47,12 @@ def record_responsify(serializer, mimetype):
         response.last_modified = record.updated
         if headers is not None:
             response.headers.extend(headers)
+
+        if links_factory is not None:
+            add_link_header(response, links_factory(pid))
+
         return response
+
     return view
 
 
@@ -67,5 +72,23 @@ def search_responsify(serializer, mimetype):
         response.status_code = code
         if headers is not None:
             response.headers.extend(headers)
+
+        if links is not None:
+            add_link_header(response, links)
+
         return response
+
     return view
+
+
+def add_link_header(response, links):
+    """Add a Link HTTP header to a REST response.
+
+    :param response: REST response instance
+    :param links: Dictionary of links
+    """
+    if links is not None:
+        response.headers.extend({
+            'Link': ', '.join([
+                  '<{0}>; rel="{1}"'.format(l, r) for r, l in links.items()])
+        })


### PR DESCRIPTION
* FIX Fixes missing links between URIs in response headers. These
  links were included in the JSON object, but not in the HTTP headers,
  as suggested on https://tools.ietf.org/html/rfc5988.  (closes #70)

* Increases test coverage.

Signed-off-by: Orestis Melkonian <melkon.or@gmail.com>